### PR TITLE
Disable clamav-daemon

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   author: First Last
   description: Skeleton Ansible role
-  company: CISA NCATS
+  company: CISA Cyber Assessments
   license: CC0
   min_ansible_version: 2.0
   platforms:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,10 +12,14 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_packages(host):
     """Test that the appropriate packages were installed."""
-    if host.system_info.distribution == "fedora":
+    distribution = host.system_info.distribution
+    if distribution == "fedora":
         pkgs = ["clamav", "clamav-update"]
-    else:
+    elif distribution == "debian":
         pkgs = ["clamav-daemon"]
+    else:
+        # We don't support this distribution
+        assert False
     packages = [host.package(pkg) for pkg in pkgs]
     installed = [package.is_installed for package in packages]
     assert len(pkgs) != 0

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -36,3 +36,13 @@ def test_packages(host):
 def test_files_and_dirs(host, path):
     """Test that the expected files and directories were created."""
     assert host.file(path).exists
+
+
+@pytest.mark.parametrize(
+    "service,isEnabled", [("clamav-daemon", False), ("clamav-freshclam", True)]
+)
+def test_services(host, service, isEnabled):
+    """Test that the expected services were enabled or disabled as intended."""
+    if host.system_info.distribution == "debian":
+        svc = host.service(service)
+        assert svc.is_enabled == isEnabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,12 @@
       systemd:
         daemon_reload: true
 
+    # Debian seems to enable clamav-daemon by default
+    - name: Disable clamav-daemon
+      service:
+        name: clamav-daemon
+        enabled: no
+
     # freshclam is run via a cron job on Fedora, so there is no
     # service to start in that case
     - name: Start and enable freshclam


### PR DESCRIPTION
Debian apparently enables the `clamav-daemon` service by default.  We don't want that service running, so this pull request remedies that.  It also adds a Debian-only test to make sure that `clamav-daemon` and `clamav-freshclam` are enabled/disabled as intended.

This pull request resolves #2.