### PR TITLE
Fix misidentified init system

### DIFF
--- a/molecule/debian-only/prepare.yml
+++ b/molecule/debian-only/prepare.yml
@@ -24,19 +24,3 @@
       package:
         name:
           - init
-
-# The Ubuntu Xenial Docker image we are using
-# (geerlingguy/docker-ubuntu1604-ansible:latest) needs a cache update
-# before it can install anything.
-- name: Group hosts by OS distribution and major version
-  hosts: all
-  tasks:
-    - name: Group hosts by OS distribution and major version
-      group_by:
-        key: os_{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_major_version'] }}
-- name: Update apt cache
-  hosts: os_Ubuntu_16
-  tasks:
-    - name: Update apt cache
-      apt:
-        update_cache: yes

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -25,7 +25,7 @@
         name:
           - init
 
-# The Ubuntu Xenial Docker image we are using
+# The Ubuntu 16.04 Docker image we are using
 # (geerlingguy/docker-ubuntu1604-ansible:latest) needs a cache update
 # before it can install anything.
 - name: Group hosts by OS distribution and major version
@@ -34,7 +34,7 @@
     - name: Group hosts by OS distribution and major version
       group_by:
         key: os_{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_major_version'] }}
-- name: Update apt cache
+- name: Update apt cache (Ubuntu 16)
   hosts: os_Ubuntu_16
   tasks:
     - name: Update apt cache

--- a/molecule/ubuntu-only/prepare.yml
+++ b/molecule/ubuntu-only/prepare.yml
@@ -1,5 +1,5 @@
 ---
-# The Ubuntu Xenial Docker image we are using
+# The Ubuntu 16.04 Docker image we are using
 # (geerlingguy/docker-ubuntu1604-ansible:latest) needs a cache update
 # before it can install anything.
 - name: Group hosts by OS distribution and major version
@@ -8,7 +8,7 @@
     - name: Group hosts by OS distribution and major version
       group_by:
         key: os_{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_major_version'] }}
-- name: Update apt cache
+- name: Update apt cache (Ubuntu 16)
   hosts: os_Ubuntu_16
   tasks:
     - name: Update apt cache


### PR DESCRIPTION
Add code to `prepare.yml` to install init on Debian images.  This is a workaround for the fact that testinfra currently misidentifies the init system on these hosts.

See philpep/testinfra#416 for more details.