### PR TITLE
Revert "Keep the name when copying the virus scanning script"

### DIFF
--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -30,7 +30,7 @@ def test_packages(host):
     "path",
     [
         # The virus scan cron job
-        "/etc/cron.weekly/virus_scan.sh",
+        "/etc/cron.weekly/virus_scan",
         # The clamav log directory (created for Fedora)
         "/var/log/clamav",
         # freshclam virus signatures

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Install virus_scan cron job
   copy:
     src: virus_scan.sh
-    dest: /etc/cron.weekly
+    dest: /etc/cron.weekly/virus_scan
     mode: 0755
 
 - name: Systemd setup


### PR DESCRIPTION
This reverts commit 7e2072dd38a7eb38640adf718f6c6499381ed9be.

Cron job was not running due to name change.

`run-parts` (used by `cron`) has strict naming rules.  The script cannot have a `.` in it:
See:
https://manpages.debian.org/buster/debianutils/run-parts.8.en.html

