### PR TITLE
Add support for Kali Linux

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,9 @@ galaxy_info:
       versions:
         - stretch
         - buster
+        # Kali linux isn't an option here, but it is based on Debian
+        # testing
+        - bullseye
     - name: Fedora
       versions:
         - 29

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -38,6 +38,13 @@ platforms:
   #   image: fedora:30
   - name: fedora31
     image: fedora:31
+  - name: kali_systemd
+    image: cisagov/docker-kali-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
   - name: ubuntu_bionic_systemd
     image: geerlingguy/docker-ubuntu1604-ansible:latest
     privileged: yes
@@ -54,6 +61,13 @@ platforms:
     pre_build_image: yes
 provisioner:
   name: ansible
+  config_options:
+    # The OS family and distribution for Kali is "Kali GNU/Linux",
+    # which is not an allowable group name in Ansible due to the space
+    # and the slash.  This option converts those characters to
+    # underscores when creating the group name.
+    defaults:
+      force_valid_group_names: always
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -15,3 +15,15 @@
     - name: Update apt cache
       apt:
         update_cache: yes
+
+# We want to copy a cron job to /etc/cron.daily, so that directory
+# needs to exist.  In our Kali image it does not, so we need to
+# install a cron implementation.  On Kali, the default cron package
+# name is called cron.
+- name: Install cron (Kali)
+  hosts: 'os_Kali_GNU_Linux'
+  tasks:
+    - name: Install cron
+      package:
+        name:
+          - cron

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -17,7 +17,7 @@ def test_packages(host):
     distribution = host.system_info.distribution
     if distribution == "fedora":
         pkgs = ["clamav", "clamav-update"]
-    elif distribution == "debian" or distribution == "ubuntu":
+    elif distribution == "debian" or distribution == "ubuntu" or distribution == "kali":
         pkgs = ["clamav-daemon"]
     else:
         # We don't support this distribution


### PR DESCRIPTION
## 🗣 Description

This pull request adds support (molecule testing) for Kali Linux.  I didn't do this before because I couldn't find a systemd-enabled Kali Docker image, and I was assuming that Kali would work identically to Debian.  This appears not to be the case, so I created [a systemd-enabled Kali Docker image](https://github.com/cisagov/docker-kali-ansible) for use here.

## 💭 Motivation and Context

We need ClamAV support for the Kali AMI we are building for the COOL.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
