### PR TITLE
Handle Kali case explicitly and pull in upstream changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements-test.txt
-      - name: Install pre-commit hooks
+      - name: Set up pre-commit hook environments
         run: pre-commit install-hooks
       - name: Run pre-commit on all files
         run: pre-commit run --all-files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,5 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements-test.txt
+      - name: Install pre-commit hooks
+        run: pre-commit install-hooks
       - name: Run pre-commit on all files
         run: pre-commit run --all-files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on: [
   pull_request
 ]
 
+env:
+  PIP_CACHE_DIR: ~/.cache/pip
+  PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,7 +25,7 @@ jobs:
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:
-          path: ~/.cache/pip
+          path: ${{ env.PIP_CACHE_DIR }}
           key: "${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/requirements-test.txt') }}"
           restore-keys: |
@@ -31,7 +35,7 @@ jobs:
       - name: Cache pre-commit hooks
         uses: actions/cache@v1
         with:
-          path: ~/.cache/pre-commit
+          path: ${{ env.PRE_COMMIT_CACHE_DIR }}
           key: "${{ runner.os }}-pre-commit-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .mypy_cache
-__pycache__
 .python-version
+__pycache__

--- a/.mdl_config.json
+++ b/.mdl_config.json
@@ -3,5 +3,8 @@
     "code_blocks": false,
     "tables": false
   },
+  "MD024": {
+    "allow_different_nesting": true
+  },
   "default": true
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args:
           - --config=.mdl_config.json
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.20.0
+    rev: v1.21.0
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -47,7 +47,7 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -61,7 +61,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.4
+    rev: v2.1.0
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/pre-commit/mirrors-isort
@@ -76,19 +76,19 @@ repos:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.12.0
+    rev: v1.27.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate_no_variables
+      - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 1.19.1
+    rev: 2.0.2
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.761
+    rev: v0.770
     hooks:
       - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.27.0
+    rev: v1.29.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -85,7 +85,7 @@ repos:
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.2
+    rev: 2.0.4
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,8 +13,9 @@ galaxy_info:
       versions:
         - stretch
         - buster
-        # Kali linux isn't an option here, but it is based on Debian
-        # testing
+        # Kali linux isn't an option here, but it is based on
+        # Debian Testing:
+        # https://www.kali.org/docs/policy/kali-linux-relationship-with-debian
         - bullseye
     - name: Fedora
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,9 @@ galaxy_info:
       versions:
         - stretch
         - buster
+        # Kali linux isn't an option here, but it is based on Debian
+        # testing
+        - bullseye
     - name: Fedora
       versions:
         - 29
@@ -21,6 +24,10 @@ galaxy_info:
         # can't use Fedora 30.
         # - 30
         - 31
+    - name: Ubuntu
+      versions:
+        - bionic
+        - xenial
   galaxy_tags:
     - skeleton
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,7 +14,7 @@ platforms:
     image: debian:buster-slim
   - name: debian11
     image: debian:bullseye-slim
-  - name: kalilinux
+  - name: kali
     image: kalilinux/kali-rolling
   - name: fedora29
     image: fedora:29

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,7 +15,7 @@ platforms:
   - name: debian11
     image: debian:bullseye-slim
   - name: kalilinux
-    image: kalilinux/kali-linux-docker
+    image: kalilinux/kali-rolling
   - name: fedora29
     image: fedora:29
   # Ansible currently insists on installing python2-dnf, which does

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,6 +12,10 @@ platforms:
     image: debian:stretch-slim
   - name: debian10
     image: debian:buster-slim
+  - name: debian11
+    image: debian:bullseye-slim
+  - name: kalilinux
+    image: kalilinux/kali-linux-docker
   - name: fedora29
     image: fedora:29
   # Ansible currently insists on installing python2-dnf, which does
@@ -21,6 +25,10 @@ platforms:
   #   image: fedora:30
   - name: fedora31
     image: fedora:31
+  - name: ubuntu16
+    image: ubuntu:xenial
+  - name: ubuntu18
+    image: ubuntu:bionic
 provisioner:
   name: ansible
   lint:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -17,11 +17,11 @@
         update_cache: yes
 
 # We want to copy a cron job to /etc/cron.daily, so that directory
-# needs to exist.  In our Kali image it does not, so we need to
-# install a cron implementation.  On Kali, the default cron package
-# name is called cron.
+# needs to exist.  In our Kali and Debian 11 images it does not, so we
+# need to install a cron implementation.  On these platforms, the
+# default cron package name is called cron.
 - name: Install cron (Kali)
-  hosts: 'os_Kali_GNU_Linux'
+  hosts: os_Kali_GNU_Linux | os_Debian
   tasks:
     - name: Install cron
       package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,13 +4,11 @@
   vars:
     params:
       files:
-        - "{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}.yml"
-        # The OS family and distribution for Kali is "Kali GNU/Linux",
-        # which is not an allowable file name in Linux due to the
-        # slash.  We will allow Kali to fall through and use the
-        # Debian vars file.
-        - Debian.yml
+        # Add regex_replace() filters to remove spaces and
+        # slashes. This allows the OS family/distribution for Kali,
+        # "Kali GNU/Linux", to be easily mapped to a vars file.
+        - "{{ ansible_distribution | regex_replace('[ /]', '_') }}.yml"
+        - "{{ ansible_os_family | regex_replace('[ /]', '_') }}.yml"
       paths:
         - "{{ role_path }}/vars"
 
@@ -30,13 +28,11 @@
   vars:
     params:
       files:
-        - setup_{{ ansible_distribution }}.yml
-        - setup_{{ ansible_os_family }}.yml
-        # The OS family and distribution for Kali is "Kali GNU/Linux",
-        # which is not an allowable file name in Linux due to the
-        # slash.  We will allow Kali to fall through and use the
-        # Debian setup tasks file.
-        - setup_Debian.yml
+        # Add regex_replace() filters to remove spaces and
+        # slashes. This allows the OS family/distribution for Kali,
+        # "Kali GNU/Linux", to be easily mapped to a vars file.
+        - setup_{{ ansible_distribution | regex_replace('[ /]', '_') }}.yml
+        - setup_{{ ansible_os_family | regex_replace('[ /]', '_') }}.yml
       paths:
         - "{{ role_path }}/tasks"
 

--- a/tasks/setup_Kali_GNU_Linux.yml
+++ b/tasks/setup_Kali_GNU_Linux.yml
@@ -1,0 +1,3 @@
+---
+- name: Use Debian tasks for Kali
+  include_tasks: setup_Debian.yml

--- a/vars/Kali_GNU_Linux.yml
+++ b/vars/Kali_GNU_Linux.yml
@@ -1,0 +1,7 @@
+---
+# vars file for Kali
+
+# The ClamAV package names.  These values are identical to those for
+# Debian.
+package_names:
+  - clamav-daemon


### PR DESCRIPTION
## 🗣 Description

In this pull request I modify the code to handle the Kali case explicitly.  I also pull in upstream changes from [cisagov/skeleton-ansible-role](https://github.com/cisagov/skeleton-ansible-role).

## 💭 Motivation and Context

The `ansible_distribution` and `ansible_os_family` Ansible facts for Kali Linux contain forward slashes.  The latter, in particular, are not allowed in Linux filenames.  In previous code I had handled the Kali case by setting the default vars or tasks file to be the Debian one.  @mcdonnnj took a different tack, where he filtered those facts through a `regex_replace()` filter and thus handled the Kali case explicitly.  This is a cleaner and more explicit way of doing things, and is therefore preferred.

@mcdonnnj also pointed out to me that Kali Linux does not always use the Debian packages directly, but in some cases hosts their own versions of packages that may install other dependencies or differ in other ways.  Therefore there is no guarantee that setting the default vars or tasks file to the Debian one and letting Kali "fall through" to Debian (a la a `switch` statement) will always be the correct thing to do.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
