### PR TITLE
Install cron on Kali

### DIFF
--- a/vars/Kali.yml
+++ b/vars/Kali.yml
@@ -1,0 +1,9 @@
+---
+# vars file for Kali
+
+# The ClamAV package names
+package_names:
+  - clamav-daemon
+  # Kali 2020.4 does not ship with a cron implementation, but we need
+  # one.
+  - cron


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the installation of the `cron` package on Kali Linux.

## 💭 Motivation and Context ##

While working on cisagov/kali-packer#47, I discovered that Kali 2020.4 does not by default include a cron implementation.  We require such an implementation for the ClamAV cron job associated with this Ansible role.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.  I also verified that this fixes the issue that was breaking my Kali AMI build in cisagov/kali-packer#47.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
