### PR TITLE
Ensure the clamav-freshclam SystemD service runs on Fedora 34

### DIFF
--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -51,13 +51,18 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  # systemd is not required for this role on RedHat
+  # systemd is not required for this role on Fedora 32 and 33
   - name: fedora32
     image: fedora:32
   - name: fedora33
     image: fedora:33
-  - name: fedora34
-    image: fedora:34
+  - name: fedora34_systemd
+    image: geerlingguy/docker-fedora34-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
   - name: ubuntu_18_systemd
     image: geerlingguy/docker-ubuntu1804-ansible:latest
     privileged: yes

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,4 +1,31 @@
 ---
+# When installing packages during later steps, the Fedora Docker
+# images we are using (geerlingguy/docker-fedora32-ansible:latest and
+# cisagov/docker-fedora33-ansible:latest) can throw sporadic errors
+# like:
+#
+# No such file or directory: '/var/cache/dnf/metadata_lock.pid'
+#
+# Our fix is to ensure that systemd finishes initializing before
+# continuing on to the converge tasks.  For details see:
+# https://www.jeffgeerling.com/blog/2020/resolving-fedora-dnf-error-no-such-file-or-directory-varlibdnfrpmdblockpid
+- name: Group hosts by OS distribution
+  hosts: all
+  tasks:
+    - name: Group hosts by OS distribution
+      group_by:
+        key: os_{{ ansible_distribution }}_{{ ansible_distribution_version }}
+- name: Wait for systemd to complete initialization (Fedora 34)
+  hosts: os_Fedora_34
+  tasks:
+    - name: Wait for systemd to complete initialization # noqa 303
+      command: systemctl is-system-running
+      register: systemctl_status
+      until: "'running' in systemctl_status.stdout"
+      retries: 30
+      delay: 5
+      when: ansible_service_mgr == 'systemd'
+
 - name: Import upgrade playbook
   ansible.builtin.import_playbook: upgrade.yml
 

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,8 +1,7 @@
 ---
 # When installing packages during later steps, the Fedora Docker
-# images we are using (geerlingguy/docker-fedora32-ansible:latest and
-# cisagov/docker-fedora33-ansible:latest) can throw sporadic errors
-# like:
+# image we are using (geerlingguy/docker-fedora34-ansible:latest) can
+# throw sporadic errors like:
 #
 # No such file or directory: '/var/cache/dnf/metadata_lock.pid'
 #

--- a/molecule/fedora/molecule.yml
+++ b/molecule/fedora/molecule.yml
@@ -23,13 +23,18 @@ platforms:
   #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
   #   command: /lib/systemd/systemd
   #   pre_build_image: yes
-  # systemd is not required for this role on RedHat
+  # systemd is not required for this role on Fedora 32 or 33
   - name: fedora32
     image: fedora:32
   - name: fedora33
     image: fedora:33
-  - name: fedora34
-    image: fedora:34
+  - name: fedora34_systemd
+    image: geerlingguy/docker-fedora34-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
 provisioner:
   name: ansible
   inventory:

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -47,7 +47,7 @@ def test_files_and_dirs(host, path):
 )
 def test_services_debian(host, service, is_enabled):
     """Test that the expected services were enabled or disabled as intended."""
-    if host.system_info.distribution in ["debian", "ubuntu"]:
+    if host.system_info.distribution in ["debian", "kali", "ubuntu"]:
         svc = host.service(service)
         assert svc.is_enabled == is_enabled
 

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -33,8 +33,6 @@ def test_packages(host):
     [
         # The virus scan cron job
         "/etc/cron.weekly/virus_scan",
-        # The clamav log directory (created for Fedora)
-        "/var/log/clamav",
         # freshclam virus signatures
         "/var/lib/clamav/bytecode.cvd",
     ],

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -17,7 +17,7 @@ def test_packages(host):
     distribution = host.system_info.distribution
     if distribution == "fedora":
         pkgs = ["clamav", "clamav-update"]
-    elif distribution == "debian" or distribution == "ubuntu" or distribution == "kali":
+    elif distribution in ["debian", "kali", "ubuntu"]:
         pkgs = ["clamav-daemon"]
     else:
         # We don't support this distribution
@@ -45,13 +45,22 @@ def test_files_and_dirs(host, path):
 
 
 @pytest.mark.parametrize(
-    "service,isEnabled", [("clamav-daemon", False), ("clamav-freshclam", True)]
+    "service,is_enabled", [("clamav-daemon", False), ("clamav-freshclam", True)]
 )
-def test_services(host, service, isEnabled):
+def test_services_debian(host, service, is_enabled):
     """Test that the expected services were enabled or disabled as intended."""
-    if (
-        host.system_info.distribution == "debian"
-        or host.system_info.distribution == "ubuntu"
-    ):
+    if host.system_info.distribution in ["debian", "ubuntu"]:
         svc = host.service(service)
-        assert svc.is_enabled == isEnabled
+        assert svc.is_enabled == is_enabled
+
+
+@pytest.mark.parametrize(
+    "service,is_enabled", [("clamav-clamonacc", False), ("clamav-freshclam", True)]
+)
+def test_services_fedora(host, service, is_enabled):
+    """Test that the expected services were enabled or disabled as intended."""
+    if host.system_info.distribution in ["fedora"] and host.system_info.release in [
+        "34"
+    ]:
+        svc = host.service(service)
+        assert svc.is_enabled == is_enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,10 @@
     params:
       files:
         - setup_{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml
+        # The ansible_distribution_release variable is always empty
+        # for Fedora, so this is necessary since we want to do
+        # something different for Fedora 34.
+        - setup_{{ ansible_distribution }}_{{ ansible_distribution_version }}.yml
         - setup_{{ ansible_distribution }}.yml
         - setup_{{ ansible_os_family }}.yml
       paths:

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -5,16 +5,16 @@
   ansible.builtin.systemd:
     daemon_reload: true
 
-# Debian seems to enable clamav-daemon by default
-- name: Disable clamav-daemon
+# Debian seems to enable the clamav daemon by default
+- name: Disable main clamav daemon
   ansible.builtin.service:
-    name: clamav-daemon
+    name: "{{ clamav_service_name }}"
     enabled: no
 
-# freshclam is run via a cron job on RedHat, so there is no service to
-# start in that case
+# freshclam is run via a cron job on Fedora <34, so there is no
+# service to start in that case
 - name: Start and enable freshclam
   ansible.builtin.service:
-    name: clamav-freshclam
+    name: "{{ freshclam_service_name }}"
     enabled: yes
     state: started

--- a/tasks/setup_Fedora_34.yml
+++ b/tasks/setup_Fedora_34.yml
@@ -1,0 +1,1 @@
+setup_Debian.yml

--- a/tasks/setup_RedHat.yml
+++ b/tasks/setup_RedHat.yml
@@ -1,12 +1,4 @@
 ---
-- name: Create /var/log/clamav directory
-  ansible.builtin.file:
-    owner: root
-    group: root
-    mode: 0700
-    path: /var/log/clamav
-    state: directory
-
 # This happens automatically on Debian or Fedora >=34 when we start
 # the freshclam service
 - name: Run freshclam

--- a/tasks/setup_RedHat.yml
+++ b/tasks/setup_RedHat.yml
@@ -7,8 +7,8 @@
     path: /var/log/clamav
     state: directory
 
-# This happens automatically on Debian when we start the
-# clamav-freshclam service
+# This happens automatically on Debian or Fedora >=34 when we start
+# the freshclam service
 - name: Run freshclam
   ansible.builtin.command: /usr/bin/freshclam
   args:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,7 @@
 ---
-# vars file for Debian
+clamav_service_name: clamav-daemon
+
+freshclam_service_name: clamav-freshclam
 
 # The ClamAV package names
 package_names:

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,5 +1,7 @@
 ---
-# vars file for Fedora
+clamav_service_name: clamav-clamonacc
+
+freshclam_service_name: clamav-freshclam
 
 # The ClamAV package names
 package_names:

--- a/vars/Kali.yml
+++ b/vars/Kali.yml
@@ -1,5 +1,7 @@
 ---
-# vars file for Kali
+clamav_service_name: clamav-daemon
+
+freshclam_service_name: clamav-freshclam
 
 # The ClamAV package names
 package_names:

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,7 @@
 ---
-# vars file for RedHat
+clamav_service_name: clamav-clamonacc
+
+freshclam_service_name: clamav-freshclam
 
 # The ClamAV package names
 package_names:


### PR DESCRIPTION
## 🗣 Description ##

This pull requests modifies this Ansible role to ensure that the `clamav-freshclam` SystemD service is enabled for Fedora 34.

## 💭 Motivation and context ##

@dav3r noticed this morning that `freshclam` had not been run on one of our FreeIPA instances since it was deployed about a month ago.  This turned out to be because Fedora 34 switched from running `freshclam` via a `cron` job to running it via a SystemD service just like Debian does.

Resolves #31.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
