### PR TITLE
Fix bug where ClamAV scans are not running on Fedora Linux

### DIFF
--- a/files/virus_scan.sh
+++ b/files/virus_scan.sh
@@ -16,6 +16,6 @@ clamscan --infected --recursive \
   /
 
 # if any infections are found, touch the detection file
-if ! grep -q "^Infected files: 0$" ${LAST_SCAN_LOG_FILENAME}; then
+if ! grep --quiet "^Infected files: 0$" ${LAST_SCAN_LOG_FILENAME}; then
   touch ${LAST_DETECTION_FILENAME}
 fi

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -33,17 +33,17 @@
   ansible.builtin.import_playbook: python.yml
 
 # We want to copy a cron job to /etc/cron.daily, so that directory
-# needs to exist.  In our Debian 11 image it does not, so we need to
-# install a cron implementation.  On this platform, the default cron
-# package name is called cron.
+# needs to exist.  In our Debian Bullseye image it does not, so we
+# need to install a cron implementation.  On this platform, the
+# default cron package name is called cron.
 - name: Group hosts by OS distribution and major version
   hosts: all
   tasks:
     - name: Group hosts by OS distribution
       ansible.builtin.group_by:
-        key: os_{{ ansible_distribution }}_{{ ansible_distribution_major_version }}
+        key: os_{{ ansible_distribution }}_{{ ansible_distribution_release }}
 - name: Debian Bullseye-specific tasks
-  hosts: os_Debian_11
+  hosts: os_Debian_bullseye
   tasks:
     - name: Install cron
       ansible.builtin.package:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,7 +1,8 @@
 ---
 # When installing packages during later steps, the Fedora Docker
-# image we are using (geerlingguy/docker-fedora34-ansible:latest) can
-# throw sporadic errors like:
+# images we are using (geerlingguy/docker-fedora34-ansible:latest and
+# geerlingguy/docker-fedora35-ansible:latest) can throw sporadic
+# errors like:
 #
 # No such file or directory: '/var/cache/dnf/metadata_lock.pid'
 #
@@ -13,9 +14,9 @@
   tasks:
     - name: Group hosts by OS distribution
       group_by:
-        key: os_{{ ansible_distribution }}_{{ ansible_distribution_version }}
-- name: Wait for systemd to complete initialization (Fedora 34)
-  hosts: os_Fedora_34
+        key: os_{{ ansible_distribution }}
+- name: Wait for systemd to complete initialization (Fedora)
+  hosts: os_Fedora
   tasks:
     - name: Wait for systemd to complete initialization # noqa 303
       command: systemctl is-system-running

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -19,7 +19,7 @@
   hosts: os_Fedora
   tasks:
     - name: Wait for systemd to complete initialization # noqa 303
-      command: systemctl is-system-running
+      ansible.builtin.command: systemctl is-system-running
       register: systemctl_status
       until: "'running' in systemctl_status.stdout"
       retries: 30

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,23 +17,23 @@
 
 - name: Install virus_scan cron job
   ansible.builtin.copy:
-    src: virus_scan.sh
     dest: /etc/cron.{{ clamav_cron_frequency }}/virus_scan
     mode: 0755
+    src: virus_scan.sh
 
 - name: Ensure that log folder exists
   ansible.builtin.file:
+    mode: 0755
     path: /var/log/clamav
     state: directory
-    mode: 0755
 
 - name: Ensure log file will be world-readable
   ansible.builtin.file:
     access_time: preserve
+    mode: 0644
     modification_time: preserve
     path: /var/log/clamav/lastscan.log
     state: touch
-    mode: 0644
 
 - name: Load tasks file for systemd setup
   ansible.builtin.include_tasks: setup_systemd.yml
@@ -45,6 +45,6 @@
 
 - name: Wait for new signatures to be downloaded and installed by freshclam
   ansible.builtin.wait_for:
-    timeout: 600
     path: /var/lib/clamav/bytecode.cvd
     state: present
+    timeout: 600

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Install ClamAV packages
   ansible.builtin.package:
-    name: '{{ package_names }}'
+    name: "{{ package_names }}"
     state: present
 
 - name: Install virus_scan cron job

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,7 +39,7 @@
       when: ansible_distribution != "Fedora"
 
     # Fedora has SELinux enabled, and if this module actually creates
-    # the file it needs to do so with the correct values for the the
+    # the file it needs to do so with the correct values for the
     # seuser, serole, setype, and selevel.  This is so that the
     # clamscan process (which runs as antivirus_t) can access the
     # file.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,12 +28,36 @@
     state: directory
 
 - name: Ensure log file will be world-readable
-  ansible.builtin.file:
-    access_time: preserve
-    mode: 0644
-    modification_time: preserve
-    path: /var/log/clamav/lastscan.log
-    state: touch
+  block:
+    - name: Ensure log file will be world-readable (not Fedora)
+      ansible.builtin.file:
+        access_time: preserve
+        mode: 0644
+        modification_time: preserve
+        path: /var/log/clamav/lastscan.log
+        state: touch
+      when: ansible_distribution != "Fedora"
+
+    # Fedora has SELinux enabled, and if this module actually creates
+    # the file it needs to do so with the correct values for the the
+    # seuser, serole, setype, and selevel.  This is so that the
+    # clamscan process (which runs as antivirus_t) can access the
+    # file.
+    #
+    # I determined the correct values to use by running restorecon on
+    # /var/log/clamav/lastscan.log on a live system.
+    - name: Ensure log file will be world-readable (Fedora)
+      ansible.builtin.file:
+        access_time: preserve
+        mode: 0644
+        modification_time: preserve
+        path: /var/log/clamav/lastscan.log
+        selevel: s0
+        serole: object_r
+        setype: antivirus_log_t
+        seuser: system_u
+        state: touch
+      when: ansible_distribution == "Fedora"
 
 - name: Load tasks file for systemd setup
   ansible.builtin.include_tasks: setup_systemd.yml

--- a/tasks/setup_manual.yml
+++ b/tasks/setup_manual.yml
@@ -3,6 +3,6 @@
 # It happens automatically with SystemD when registering freshclam service.
 
 - name: Run freshclam
-  ansible.builtin.command: /usr/bin/freshclam
-  args:
+  ansible.builtin.command:
+    cmd: /usr/bin/freshclam
     creates: /var/lib/clamav/bytecode.cvd

--- a/tasks/setup_systemd.yml
+++ b/tasks/setup_systemd.yml
@@ -8,13 +8,13 @@
 # Debian seems to enable the clamav daemon by default
 - name: Disable main clamav daemon
   ansible.builtin.service:
-    name: "{{ clamav_service_name }}"
     enabled: no
+    name: "{{ clamav_service_name }}"
 
 # freshclam is run via a cron job on Fedora <34, so there is no
 # service to start in that case
 - name: Start and enable freshclam
   ansible.builtin.service:
-    name: "{{ freshclam_service_name }}"
     enabled: yes
+    name: "{{ freshclam_service_name }}"
     state: started


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes a bug where ClamAV scans are not running on Fedora Linux because a file is created by this Ansible role but isn't labeled correctly for SELinux.

## 💭 Motivation and context ##

The ClamAV scans must run.  This is a requirement of our ATO.  Resolves cisagov/cool-system-internal#111.

## 🧪 Testing ##

Automated testing passes.  I also created a FreeIPA staging AMI with these changes and confirmed that it functions as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.