### PR TITLE
Add kali-dev package repo

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,8 @@
     - ansible_distribution == "Kali"
 
 - name: Load var file with package names based on the OS type
-  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  ansible.builtin.include_vars:
+    file: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:
@@ -67,14 +68,16 @@
       when: ansible_distribution == "Fedora"
 
 - name: Ensure configuration for freshclam
-  ansible.builtin.include_tasks: configure.yml
+  ansible.builtin.include_tasks:
+    file: configure.yml
   vars:
     task_conf_file: "{{ freshclam_configuration_path }}"
     task_conf_parameters: "{{ clamav_freshclam_configuration }}"
   when: clamav_freshclam_configuration
 
 - name: Ensure configuration for clamd
-  ansible.builtin.include_tasks: configure.yml
+  ansible.builtin.include_tasks:
+    file: configure.yml
   vars:
     task_conf_file: "{{ clamd_configuration_path }}"
     task_conf_parameters: "{{ clamav_clamd_configuration }}"
@@ -90,11 +93,13 @@
   when: clamav_scan_copy or clamav_scan_move | bool
 
 - name: Load tasks file for systemd setup
-  ansible.builtin.include_tasks: setup_systemd.yml
+  ansible.builtin.include_tasks:
+    file: setup_systemd.yml
   when: ansible_service_mgr == 'systemd'
 
 - name: Load tasks file for manual setup
-  ansible.builtin.include_tasks: setup_manual.yml
+  ansible.builtin.include_tasks:
+    file: setup_manual.yml
   when: ansible_service_mgr != 'systemd'
 
 - name: Wait for new signatures to be downloaded and installed by freshclam

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: Load tasks file for adding kali-dev package repo for Kali
+  ansible.builtin.include_tasks:
+    file: setup_Kali.yml
+  when:
+    - ansible_os_family == "Debian"
+    - ansible_distribution == "Kali"
+
 - name: Load var file with package names based on the OS type
   ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:

--- a/tasks/setup_Kali.yml
+++ b/tasks/setup_Kali.yml
@@ -2,7 +2,7 @@
 # Add kali-dev package repo
 #
 # TODO: These tasks should be removed once libtfm1>=0.13.1-1 is
-# available in kali-rolling.
+# available in kali-rolling.  See #61 for more details.
 
 - name: Add the kali-dev package repository
   ansible.builtin.apt_repository:

--- a/tasks/setup_Kali.yml
+++ b/tasks/setup_Kali.yml
@@ -1,0 +1,17 @@
+---
+# Add kali-dev package repo
+#
+# TODO: These tasks should be removed once libtfm1>=0.13.1-1 is
+# available in kali-rolling.
+
+- name: Add the kali-dev package repository
+  ansible.builtin.apt_repository:
+    repo: deb http://http.kali.org/kali kali-dev main contrib non-free
+
+- name: Update the cache with the kali-dev goodness
+  ansible.builtin.package:
+    update_cache: yes
+  # This cache update can cause idempotence to fail, so tell molecule
+  # to ignore any changes this task produces when testing idempotence.
+  tags:
+    - molecule-idempotence-notest


### PR DESCRIPTION
## 🗣 Description ##

This pull requests adds the `kali-dev` package repository to Kali Linux.

## 💭 Motivation and context ##

This is necessary to work around a broken `libclamav9` package in the `kali-rolling` package repository.  Resolves #59.

## 🧪 Testing ##

All automated tests pass; they did not pass without these changes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.