### PR TITLE
Configure selinux to permit clamav to scan the system

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ None.
 | clamav_scan_quarantine_mode | Permissions to apply to quarantine directory. | `0750` | No |
 | clamav_scan_quarantine_owner | Owner to apply to quarantine directory. | `root` | No |
 | clamav_seboolean_name | The name of the SELinux boolean used to configure whether or not ClamAV is allowed to scan files.  Note that this variable is only used when SELinux is enabled. | `antivirus_can_scan_system` | No |
-| clamav_seboolean_state | The value to use for the SELinux boolean that configures whether or not ClamAV is allowed to scan files.  Note that this variable is only used when SELinux is enabled. | `antivirus_can_scan_system` | No |
+| clamav_seboolean_state | The value to use for the SELinux boolean that configures whether or not ClamAV is allowed to scan files.  Note that this variable is only used when SELinux is enabled. | `true` | No |
 
 ### Example ###
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ None.
 | clamav_scan_quarantine_group | Group owner to apply to quarantine directory. | `root` | No |
 | clamav_scan_quarantine_mode | Permissions to apply to quarantine directory. | `0750` | No |
 | clamav_scan_quarantine_owner | Owner to apply to quarantine directory. | `root` | No |
-| clamav_seboolean_name | On hosts with SELinux enabled, name of the boolean to allow clamav to scan files. | `antivirus_can_scan_system` | No |
-| clamav_seboolean_state | On hosts with SELinux enabled, wether to allow clamav to scan files. | `antivirus_can_scan_system` | No |
+| clamav_seboolean_name | The name of the SELinux boolean used to configure whether or not ClamAV is allowed to scan files.  Note that this variable is only used when SELinux is enabled. | `antivirus_can_scan_system` | No |
+| clamav_seboolean_state | The value to use for the SELinux boolean that configures whether or not ClamAV is allowed to scan files.  Note that this variable is only used when SELinux is enabled. | `antivirus_can_scan_system` | No |
 
 ### Example ###
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ None.
 | clamav_scan_quarantine_group | Group owner to apply to quarantine directory. | `root` | No |
 | clamav_scan_quarantine_mode | Permissions to apply to quarantine directory. | `0750` | No |
 | clamav_scan_quarantine_owner | Owner to apply to quarantine directory. | `root` | No |
+| clamav_seboolean_name | On hosts with SELinux enabled, name of the boolean to allow clamav to scan files. | `antivirus_can_scan_system` | No |
+| clamav_seboolean_state | On hosts with SELinux enabled, wether to allow clamav to scan files. | `antivirus_can_scan_system` | No |
 
 ### Example ###
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,4 +32,4 @@ clamav_scan_quarantine_mode: 0750
 clamav_scan_quarantine_owner: root
 
 clamav_seboolean_name: antivirus_can_scan_system
-clamav_seboolean_state: yes
+clamav_seboolean_state: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,3 +30,6 @@ clamav_scan_quarantine_directory: /var/spool/clamav
 clamav_scan_quarantine_group: root
 clamav_scan_quarantine_mode: 0750
 clamav_scan_quarantine_owner: root
+
+clamav_seboolean_name: antivirus_can_scan_system
+clamav_seboolean_state: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,6 +67,14 @@
         state: touch
       when: ansible_distribution == "Fedora"
 
+- name: "Set SELinux {{ clamav_seboolean_name }} flag persistently"
+  ansible.posix.seboolean:
+    name: "{{ clamav_seboolean_name }}"
+    persistent: yes
+    state: "{{ clamav_seboolean_state }}"
+  when:
+    - ansible_selinux.status == "enabled"
+
 - name: Ensure configuration for freshclam
   ansible.builtin.include_tasks:
     file: configure.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,7 +70,7 @@
 - name: "Set SELinux {{ clamav_seboolean_name }} flag persistently"
   ansible.posix.seboolean:
     name: "{{ clamav_seboolean_name }}"
-    persistent: yes
+    persistent: true
     state: "{{ clamav_seboolean_state }}"
   when:
     - ansible_selinux.status == "enabled"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Set a SELinux boolean to [allow ClamAV to access the system](https://www.systutorials.com/docs/linux/man/8-antivirus_selinux/).

The boolean name and state are put in a variable for flexibility.

## 💭 Motivation and context ##

Following discussions in #63, we propose this change as it might be required on RedHat variants [according to clamavAV documentation](https://docs.clamav.net/manual/Usage/Configuration.html#configure-selinux-for-clamav).

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

All automated tests pass.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.