### PR TITLE
Bugfix selinux dependency

### DIFF
--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -7,10 +7,10 @@ freshclam_service_name: clamav-freshclam
 package_names:
   - clamav
   - clamav-update
-  - python3-libsemanage
   # Later versions of Fedora do not come with a cron implementation
   # installed, but we need one.
   - cronie
+  - python3-libsemanage
 
 clamd_configuration_path: /etc/clamd.d/scan.conf
 freshclam_configuration_path: /etc/freshclam.conf

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -3,7 +3,7 @@ clamav_service_name: clamav-clamonacc
 
 freshclam_service_name: clamav-freshclam
 
-# The ClamAV package names and the python lib to handle selinux
+# The ClamAV package names, as well as the name of a Python package necessary to handle selinux
 package_names:
   - clamav
   - clamav-update

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -10,6 +10,7 @@ package_names:
   # Later versions of Fedora do not come with a cron implementation
   # installed, but we need one.
   - cronie
+  - python3-libsemanage
 
 clamd_configuration_path: /etc/clamd.d/scan.conf
 freshclam_configuration_path: /etc/freshclam.conf

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -3,14 +3,14 @@ clamav_service_name: clamav-clamonacc
 
 freshclam_service_name: clamav-freshclam
 
-# The ClamAV package names
+# The ClamAV package names and the python lib to handle selinux
 package_names:
   - clamav
   - clamav-update
+  - python3-libsemanage
   # Later versions of Fedora do not come with a cron implementation
   # installed, but we need one.
   - cronie
-  - python3-libsemanage
 
 clamd_configuration_path: /etc/clamd.d/scan.conf
 freshclam_configuration_path: /etc/freshclam.conf

--- a/vars/Fedora_38.yml
+++ b/vars/Fedora_38.yml
@@ -3,7 +3,7 @@ clamav_service_name: clamav-clamonacc
 
 freshclam_service_name: clamav-freshclam
 
-# The ClamAV package names and the python lib to handle selinux
+# The ClamAV package names, as well as the name of a Python package necessary to handle selinux
 package_names:
   - clamav
   - clamav-freshclam

--- a/vars/Fedora_38.yml
+++ b/vars/Fedora_38.yml
@@ -3,14 +3,14 @@ clamav_service_name: clamav-clamonacc
 
 freshclam_service_name: clamav-freshclam
 
-# The ClamAV package names
+# The ClamAV package names and the python lib to handle selinux
 package_names:
   - clamav
   - clamav-freshclam
+  - python3-libsemanage
   # Later versions of Fedora do not come with a cron implementation
   # installed, but we need one.
   - cronie
-  - python3-libsemanage
 
 clamd_configuration_path: /etc/clamd.d/scan.conf
 freshclam_configuration_path: /etc/freshclam.conf

--- a/vars/Fedora_38.yml
+++ b/vars/Fedora_38.yml
@@ -10,6 +10,7 @@ package_names:
   # Later versions of Fedora do not come with a cron implementation
   # installed, but we need one.
   - cronie
+  - python3-libsemanage
 
 clamd_configuration_path: /etc/clamd.d/scan.conf
 freshclam_configuration_path: /etc/freshclam.conf

--- a/vars/Fedora_38.yml
+++ b/vars/Fedora_38.yml
@@ -7,10 +7,10 @@ freshclam_service_name: clamav-freshclam
 package_names:
   - clamav
   - clamav-freshclam
-  - python3-libsemanage
   # Later versions of Fedora do not come with a cron implementation
   # installed, but we need one.
   - cronie
+  - python3-libsemanage
 
 clamd_configuration_path: /etc/clamd.d/scan.conf
 freshclam_configuration_path: /etc/freshclam.conf

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -3,10 +3,11 @@ clamav_service_name: clamav-clamonacc
 
 freshclam_service_name: clamav-freshclam
 
-# The ClamAV package names
+# The ClamAV package names and the python lib to handle selinux
 package_names:
   - clamav
   - clamav-update
+  - python3-libsemanage
 
 clamd_configuration_path: /etc/clamd.d/scan.conf
 freshclam_configuration_path: /etc/freshclam.conf

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -3,7 +3,7 @@ clamav_service_name: clamav-clamonacc
 
 freshclam_service_name: clamav-freshclam
 
-# The ClamAV package names and the python lib to handle selinux
+# The ClamAV package names, as well as the name of a Python package necessary to handle selinux
 package_names:
   - clamav
   - clamav-update


### PR DESCRIPTION
# Bugfix: needed dependency for ansible.posix.seboolean #

The target needs to have a Python library to execute `ansible.posix.seboolean` as stated [here](https://docs.ansible.com/ansible/latest/collections/ansible/posix/seboolean_module.html#requirements).

This PR adds the needed dependancy as a package to install for Fedora and RedHat (which are more likely to have selinux enabled).

