### PR TITLE
Use nice when running clamscan

### DIFF
--- a/templates/virus_scan.sh.j2
+++ b/templates/virus_scan.sh.j2
@@ -7,9 +7,9 @@ set -o pipefail
 LAST_SCAN_LOG_FILENAME='/var/log/clamav/lastscan.log'
 LAST_DETECTION_FILENAME='/var/log/clamav/last_detection'
 
-# Scan the entire file system (modulo excluded trees)
-# and write to the log
-clamscan \
+# Scan the entire file system (modulo excluded trees) and write to the
+# log.  Use nice since clamscan can be temporarily CPU-hungry.
+nice clamscan \
 {% if clamav_scan_copy %}
   --copy={{ clamav_scan_quarantine_directory }} \
 {% endif %}

--- a/templates/virus_scan.sh.j2
+++ b/templates/virus_scan.sh.j2
@@ -27,7 +27,7 @@ nice clamscan \
 {% endfor %}
   /
 
-# if any infections are found, touch the detection file
+# If any infections are found, touch the detection file.
 if ! grep --quiet "^Infected files: 0$" ${LAST_SCAN_LOG_FILENAME}; then
   touch ${LAST_DETECTION_FILENAME}
 fi


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `virus_scan` script template to run `clamscan` under `nice`.  This change was suggested by @bra1ncramp.

## 💭 Motivation and context ##

`clamscan` can be intermittently CPU-hungry, and we don't want it to interfere with important processes running on the server.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.