### PR TITLE
Clamd Permissions Fix for Debian AppArmor

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@ clamav_cron_frequency: weekly
 
 apparmor_clamd_configuration_path: /etc/apparmor.d/usr.sbin.clamd
 apparmor_freshclam_configuration_path: /etc/apparmor.d/usr.bin.freshclam
-apparmor_complain: true
+apparmor_complain: false
 
 # A dictionary of values to be configured in the clamd and freshclam configuration files.
 # Multivalued keys are specified as lists.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,9 @@
 clamav_cron_frequency: weekly
 
+# Task control to handle an AppArmor/Clamd defect
+# Defect: Defect Notes: https://bugs.launchpad.net/ubuntu/+source/clamav/+bug/1842695
+# Evidence: This issue is evident by daemon permission errors accessing clamd or freshclam
+#   log files or in AuditD logs "apparmor="DENIED""
 apparmor_clamd_configuration_path: /etc/apparmor.d/usr.sbin.clamd
 apparmor_freshclam_configuration_path: /etc/apparmor.d/usr.bin.freshclam
 apparmor_complain: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,9 @@
 clamav_cron_frequency: weekly
 
+apparmor_clamd_configuration_path: /etc/apparmor.d/usr.sbin.clamd
+apparmor_freshclam_configuration_path: /etc/apparmor.d/usr.bin.freshclam
+apparmor_complain: true
+
 # A dictionary of values to be configured in the clamd and freshclam configuration files.
 # Multivalued keys are specified as lists.
 # A Nonetype value means that the key will be removed from the file.

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -7,7 +7,7 @@
     src: "{{ task_conf_file }}"
   tags:
     - molecule-idempotence-notest
-  when: clamav_configuration_backup
+  when: clamav_configuration_backup | bool
 
 - name: Configure single-valued entries in {{ task_conf_file }}
   ansible.builtin.lineinfile:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,8 +37,8 @@
 
     - name: Reload AppArmor profiles
       ansible.builtin.service:
-        name: 'apparmor'
-        state: 'reloaded'
+        name: apparmor
+        state: reloaded
 
 - name: Reload AppArmor all profiles
   ansible.builtin.service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,9 +42,8 @@
 
 - name: Reload AppArmor all profiles
   ansible.builtin.service:
-    name: 'apparmor'
-    state: 'reloaded'
-
+    name: apparmor
+    state: reloaded
 
 - name: Install virus_scan cron job
   ansible.builtin.template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
     state: present
 
 - name: Configure AppArmor for Clamd
-  when: "ansible_apparmor.status == 'enabled' and apparmor_complain"
+  when: ansible_apparmor.status == "enabled" and apparmor_complain
   block:
     - name: Configure clamd in apparmor
       ansible.builtin.lineinfile:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,9 +22,9 @@
     - name: Configure clamd in apparmor
       ansible.builtin.lineinfile:
         firstmatch: true
-        line: "/usr/sbin/clamd flags=(complain) {"
+        line: /usr/sbin/clamd flags=(complain) {
         path: "{{ apparmor_clamd_configuration_path }}"
-        search_string: "/usr/sbin/clamd {"
+        search_string: /usr/sbin/clamd {
         state: present
 
     - name: Configure freshclam in apparmor

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,36 @@
     name: "{{ package_names }}"
     state: present
 
+- name: Configure AppArmor for Clamd
+  when: "ansible_apparmor.status == 'enabled' and apparmor_complain"
+  block:
+    - name: Configure clamd in apparmor
+      ansible.builtin.lineinfile:
+        firstmatch: true
+        line: "/usr/sbin/clamd flags=(complain) {"
+        path: "{{ apparmor_clamd_configuration_path }}"
+        search_string: "/usr/sbin/clamd {"
+        state: present
+
+    - name: Configure freshclam in apparmor
+      ansible.builtin.lineinfile:
+        firstmatch: true
+        line: "/usr/bin/freshclam flags=(attach_disconnected,complain) {"
+        path: "{{ apparmor_freshclam_configuration_path }}"
+        search_string: "/usr/bin/freshclam flags=(attach_disconnected) {"
+        state: present
+
+    - name: Reload AppArmor profiles
+      ansible.builtin.service:
+        name: 'apparmor'
+        state: 'reloaded'
+
+- name: Reload AppArmor all profiles
+  ansible.builtin.service:
+    name: 'apparmor'
+    state: 'reloaded'
+
+
 - name: Install virus_scan cron job
   ansible.builtin.template:
     dest: /etc/cron.{{ clamav_cron_frequency }}/virus_scan

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,10 +40,6 @@
         name: apparmor
         state: reloaded
 
-- name: Reload AppArmor all profiles
-  ansible.builtin.service:
-    name: apparmor
-    state: reloaded
 - name: Install virus_scan cron job
   ansible.builtin.template:
     dest: /etc/cron.{{ clamav_cron_frequency }}/virus_scan

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,6 @@
   ansible.builtin.service:
     name: apparmor
     state: reloaded
-
 - name: Install virus_scan cron job
   ansible.builtin.template:
     dest: /etc/cron.{{ clamav_cron_frequency }}/virus_scan

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,7 +98,7 @@
   vars:
     task_conf_file: "{{ freshclam_configuration_path }}"
     task_conf_parameters: "{{ clamav_freshclam_configuration }}"
-  when: clamav_freshclam_configuration
+  when: clamav_freshclam_configuration | length > 0
 
 - name: Ensure configuration for clamd
   ansible.builtin.include_tasks:
@@ -106,7 +106,7 @@
   vars:
     task_conf_file: "{{ clamd_configuration_path }}"
     task_conf_parameters: "{{ clamav_clamd_configuration }}"
-  when: clamav_clamd_configuration
+  when: clamav_clamd_configuration | length > 0
 
 - name: Ensure that quarantine folder exists
   ansible.builtin.file:
@@ -115,7 +115,7 @@
     owner: "{{ clamav_scan_quarantine_owner }}"
     path: "{{ clamav_scan_quarantine_directory }}"
     state: directory
-  when: clamav_scan_copy or clamav_scan_move | bool
+  when: (clamav_scan_copy or clamav_scan_move) | bool
 
 - name: Load tasks file for systemd setup
   ansible.builtin.include_tasks:

--- a/tasks/setup_systemd.yml
+++ b/tasks/setup_systemd.yml
@@ -8,11 +8,11 @@
 # Debian seems to enable the clamav daemon by default
 - name: Disable main clamav daemon
   ansible.builtin.service:
-    enabled: no
+    enabled: false
     name: "{{ clamav_service_name }}"
 
 - name: Start and enable freshclam
   ansible.builtin.service:
-    enabled: yes
+    enabled: true
     name: "{{ freshclam_service_name }}"
     state: started


### PR DESCRIPTION
## 🗣 Description ##

Resolve AppArmor configuration issue which prevents clamd and freshclam from running.

## 💭 Motivation and context ##

On Debian GNU/Linux 11 (bullseye), Clamd and Freshclam are not configured correctly by default with latest versions.

Apparmor Version: 2.13.6
ClamAV Version: 0.103.10

Error: Can't open /var/log/clamav/freshclam.log in append mode (check permissions!).

Defect Notes: https://bugs.launchpad.net/ubuntu/+source/clamav/+bug/1842695


## 🧪 Testing ##

Change was incorporated into internal Playbook

## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.