### PR TITLE
Bugfix: Configuration tasks should handle service restart

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,22 +1,10 @@
 ---
-- name: Handle freshclam service
+- name: Restart freshclam service
   ansible.builtin.service:
     name: "{{ freshclam_service_name }}"
-    state: stopped
-  notify: Start freschlam
+    state: restart
 
-- name: Start freschlam
+- name: Restart clamd service
   ansible.builtin.service:
-    name: "{{ freshclam_service_name }}"
-    state: started
-
-- name: Handle clamd service
-  ansible.builtin.service:
-    name: "{{ freshclam_service_name }}"
-    state: stopped
-  notify: Start clamd
-
-- name: Start clamd
-  ansible.builtin.service:
-    name: "{{ freshclam_service_name }}"
-    state: started
+    name: "{{ clamd_service_name }}"
+    state: restart

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,9 +2,9 @@
 - name: Restart freshclam service
   ansible.builtin.service:
     name: "{{ freshclam_service_name }}"
-    state: restart
+    state: restarted
 
 - name: Restart clamd service
   ansible.builtin.service:
     name: "{{ clamd_service_name }}"
-    state: restart
+    state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,5 +6,5 @@
 
 - name: Restart clamd service
   ansible.builtin.service:
-    name: "{{ clamd_service_name }}"
+    name: "{{ clamav_service_name }}"
     state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Handle freshclam service
+  ansible.builtin.service:
+    name: "{{ freshclam_service_name }}"
+    state: stopped
+  notify: Start freschlam
+
+- name: Start freschlam
+  ansible.builtin.service:
+    name: "{{ freshclam_service_name }}"
+    state: started
+
+- name: Handle clamd service
+  ansible.builtin.service:
+    name: "{{ freshclam_service_name }}"
+    state: stopped
+  notify: Start clamd
+
+- name: Start clamd
+  ansible.builtin.service:
+    name: "{{ freshclam_service_name }}"
+    state: started

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,6 +1,6 @@
 ---
 - name: Handle service configuration and notify restart if needed
-  notify: "Handle {{ task_conf_service }} service"
+  notify: "Restart {{ task_conf_service }} service"
   block:
     - name: Backup {{ task_conf_file }}
       ansible.builtin.copy:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,56 +1,48 @@
 ---
-- name: Backup {{ task_conf_file }}
-  ansible.builtin.copy:
-    dest: "{{ task_conf_file }}.{{ ansible_date_time.iso8601 }}"
-    mode: 0700
-    remote_src: true
-    src: "{{ task_conf_file }}"
-  tags:
-    - molecule-idempotence-notest
-  when: clamav_configuration_backup
+- name: Handle service configuration and notify restart if needed
+  block:
+    - name: Backup {{ task_conf_file }}
+      ansible.builtin.copy:
+        dest: "{{ task_conf_file }}.{{ ansible_date_time.iso8601 }}"
+        mode: 0700
+        remote_src: true
+        src: "{{ task_conf_file }}"
+      tags:
+        - molecule-idempotence-notest
+      when: clamav_configuration_backup
 
-- name: Configure single-valued entries in {{ task_conf_file }}
-  ansible.builtin.lineinfile:
-    line: "{{ item.key }} {{ item.value }}"
-    path: "{{ task_conf_file }}"
-    search_string: "{{ item.key }} "
-    state: present
-  loop: "{{ task_conf_parameters | dict2items | selectattr('value', 'string') }}"
+    - name: Configure single-valued entries in {{ task_conf_file }}
+      ansible.builtin.lineinfile:
+        line: "{{ item.key }} {{ item.value }}"
+        path: "{{ task_conf_file }}"
+        search_string: "{{ item.key }} "
+        state: present
+      loop: "{{ task_conf_parameters | dict2items | selectattr('value', 'string') }}"
 
-- name: Configure multi-valued entries in {{ task_conf_file }}
-  ansible.builtin.lineinfile:
-    line: "{{ item.0.key }} {{ item.1 }}"
-    path: "{{ task_conf_file }}"
-    state: present
-  loop: "{{ task_conf_parameters | dict2items | rejectattr('value', 'string') | rejectattr('value', 'none') | subelements('value') }}"
+    - name: Configure multi-valued entries in {{ task_conf_file }}
+      ansible.builtin.lineinfile:
+        line: "{{ item.0.key }} {{ item.1 }}"
+        path: "{{ task_conf_file }}"
+        state: present
+      loop: "{{ task_conf_parameters | dict2items | rejectattr('value', 'string') | rejectattr('value', 'none') | subelements('value') }}"
 
-- name: Remove unwanted values from {{ task_conf_file }}
-  ansible.builtin.lineinfile:
-    path: "{{ task_conf_file }}"
-    regexp: "^{{ item.key }} (?!{% for clamav_value in item.value %}{{ clamav_value | regex_escape() }}{{ '|' if not loop.last }}{% endfor %})"
-    state: absent
-  loop: "{{ task_conf_parameters | dict2items | rejectattr('value', 'none') }}"
+    - name: Remove unwanted values from {{ task_conf_file }}
+      ansible.builtin.lineinfile:
+        path: "{{ task_conf_file }}"
+        regexp: "^{{ item.key }} (?!{% for clamav_value in item.value %}{{ clamav_value | regex_escape() }}{{ '|' if not loop.last }}{% endfor %})"
+        state: absent
+      loop: "{{ task_conf_parameters | dict2items | rejectattr('value', 'none') }}"
 
-- name: Remove unwanted keys from {{ task_conf_file }}
-  ansible.builtin.lineinfile:
-    path: "{{ task_conf_file }}"
-    regexp: "^{{ item.key }} .*$"
-    state: absent
-  loop: "{{ task_conf_parameters | dict2items | selectattr('value', 'none') }}"
+    - name: Remove unwanted keys from {{ task_conf_file }}
+      ansible.builtin.lineinfile:
+        path: "{{ task_conf_file }}"
+        regexp: "^{{ item.key }} .*$"
+        state: absent
+      loop: "{{ task_conf_parameters | dict2items | selectattr('value', 'none') }}"
 
-- name: Set permissions on configuration file {{ task_conf_file }}
-  ansible.builtin.file:
-    mode: 0700
-    path: "{{ task_conf_file }}"
+    - name: Set permissions on configuration file {{ task_conf_file }}
+      ansible.builtin.file:
+        mode: 0700
+        path: "{{ task_conf_file }}"
 
-- name: Stop service {{ task_conf_service }}
-  ansible.builtin.service:
-    name: "{{ task_conf_service }}"
-    state: stopped
-  register: service_status
-
-- name: Restart service if it was started
-  ansible.builtin.service:
-    name: "{{ task_conf_service }}"
-    state: started
-  when: service_status.changed
+  notify: "Handle {{ task_conf_service }} service"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Backup {{ task_conf_file }}
   ansible.builtin.copy:
     dest: "{{ task_conf_file }}.{{ ansible_date_time.iso8601 }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Backup {{ task_conf_file }}
   ansible.builtin.copy:
     dest: "{{ task_conf_file }}.{{ ansible_date_time.iso8601 }}"
@@ -42,3 +43,15 @@
   ansible.builtin.file:
     mode: 0700
     path: "{{ task_conf_file }}"
+
+- name: Stop service {{ task_conf_service }}
+  ansible.builtin.service:
+    name: "{{ task_conf_service }}"
+    state: stopped
+  register: service_status
+
+- name: Restart service if it was started
+  ansible.builtin.service:
+    name: "{{ task_conf_service }}"
+    state: started
+  when: service_status.changed

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,5 +1,5 @@
 ---
-- name: Handle service configuration and notify restart if needed
+- name: Configure service and notify restart handler
   notify: "Restart {{ task_conf_service }} service"
   block:
     - name: Backup {{ task_conf_file }}

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,5 +1,6 @@
 ---
 - name: Handle service configuration and notify restart if needed
+  notify: "Handle {{ task_conf_service }} service"
   block:
     - name: Backup {{ task_conf_file }}
       ansible.builtin.copy:
@@ -44,5 +45,3 @@
       ansible.builtin.file:
         mode: 0700
         path: "{{ task_conf_file }}"
-
-  notify: "Handle {{ task_conf_service }} service"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -96,6 +96,7 @@
   vars:
     task_conf_file: "{{ freshclam_configuration_path }}"
     task_conf_parameters: "{{ clamav_freshclam_configuration }}"
+    task_conf_service: "{{ freshclam_service_name }}"
   when: clamav_freshclam_configuration
 
 - name: Ensure configuration for clamd
@@ -104,6 +105,7 @@
   vars:
     task_conf_file: "{{ clamd_configuration_path }}"
     task_conf_parameters: "{{ clamav_clamd_configuration }}"
+    task_conf_service: "{{ clamav_service_name }}"
   when: clamav_clamd_configuration
 
 - name: Ensure that quarantine folder exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -96,7 +96,7 @@
   vars:
     task_conf_file: "{{ freshclam_configuration_path }}"
     task_conf_parameters: "{{ clamav_freshclam_configuration }}"
-    task_conf_service: "{{ freshclam_service_name }}"
+    task_conf_service: freshclam
   when: clamav_freshclam_configuration
 
 - name: Ensure configuration for clamd
@@ -105,8 +105,13 @@
   vars:
     task_conf_file: "{{ clamd_configuration_path }}"
     task_conf_parameters: "{{ clamav_clamd_configuration }}"
-    task_conf_service: "{{ clamav_service_name }}"
+    task_conf_service: clamd
   when: clamav_clamd_configuration
+
+# We need to flush handlers as configuration changes might be necessary
+# to pass the wait_for signatures test.
+- name: Flush possible pending handlers
+  ansible.builtin.meta: flush_handlers
 
 - name: Ensure that quarantine folder exists
   ansible.builtin.file:


### PR DESCRIPTION
# Bugfix: Configuration tasks should handle service restart

## 🗣 Description ##

Adding two tasks to stop the service concerned by a configuration modification, then restart it if it was started.

## 💭 Motivation and context ##

We need to apply configuration just after tweaking it. Handlers can't be used because of the freshclam check.

## 🧪 Testing ##

Simple test on running systems. It is simple enough to not need external tests (ansible.builtin.service).

## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
