### PR TITLE
Add a test to verify that the `clamscan` executable is available

### DIFF
--- a/molecule/default/tests/test_packages_and_services.py
+++ b/molecule/default/tests/test_packages_and_services.py
@@ -31,6 +31,14 @@ def test_packages(host):
     assert all(installed)
 
 
+def test_clamscan_executable_present(host):
+    """Test that the clamscan executable is present.
+
+    This test is added in response to issue #49.
+    """
+    assert host.exists("clamscan")
+
+
 @pytest.mark.parametrize(
     "service,is_enabled", [("clamav-daemon", False), ("clamav-freshclam", True)]
 )


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a test to verify that the `clamscan` executable is available.

## 💭 Motivation and context ##

This is done in response to issue #49.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.