### PR TITLE
Cease excluding ARM64 platforms from Molecule testing where possible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,20 +185,6 @@ jobs:
           - amd64
           - arm64
         exclude:
-          # Debian 13 has a very recent version of systemd (currently
-          # 257), and the freshclam service cannot be started under
-          # QEMU emulation.  We support this platform, but we cannot
-          # test it until we have native ARM64 runners.  See #82 for
-          # more details.
-          - architecture: arm64
-            platform: debian13-systemd
-          # Kali has a recent version of systemd (currently 256), and
-          # the freshclam service cannot be started under QEMU
-          # emulation.  We support this platform, but we cannot test
-          # it until we have native ARM64 runners.  See #83 for more
-          # details.
-          - architecture: arm64
-            platform: kali-systemd
           # The packages that ClamAV offers directly on its website do
           # not support the ARM64 architecture.
           # https://www.clamav.net/downloads


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the exclusion of ARM64 platforms from Molecule testing where possible.

## 💭 Motivation and context ##

In many cases we no longer need to do this because we are now using native ARM64 GitHub Actions runners.

Resolves #82.
Resolves #83.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
