### PR TITLE
Stop excluding ARM64 architecture with `package_install` scenario

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,12 +215,6 @@ jobs:
         architecture:
           - amd64
           - arm64
-        exclude:
-          # The packages that ClamAV offers directly on its website do
-          # not support the ARM64 architecture.
-          # https://www.clamav.net/downloads
-          - architecture: arm64
-            scenario: package_install
         platform:
           - amazonlinux2023-systemd
           - debian11-systemd

--- a/README.md
+++ b/README.md
@@ -10,13 +10,6 @@ signatures.  The
 [ClamAV-Report](https://github.com/cisagov/clamav-report) tool can be
 used to gather scan data from systems using this role.
 
-> [!WARNING]
-> Debian Buster only offers a very old version of ClamAV (even in the
-> backports package repository) that is no longer allowed to download
-> signatures from the official ClamAV site; therefore, on this
-> platform ClamAV can *only* be installed by setting the
-> `clamav_install_from_package_manager` role variable to `false`.
-
 ## Requirements ##
 
 None.


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the `build.yml` workflow to stop excluding the ARM64 architecture when running the `package_install` scenario.

## 💭 Motivation and context ##

The packages offered by ClamAV [now support this architecture](https://www.clamav.net/downloads).

Resolves #105.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.